### PR TITLE
Feature/plan received

### DIFF
--- a/src/main/java/com/grablunchtogether/controller/PlanController.java
+++ b/src/main/java/com/grablunchtogether/controller/PlanController.java
@@ -64,10 +64,24 @@ public class PlanController {
         ServiceResult result =
                 planService.createPlan(userDto.getId(), accepterId, planCreationInput);
 
-        smsApiService.sendSmsToAccepter(userDto.getId(), accepterId ,planCreationInput);
+        smsApiService.sendSmsToAccepter(userDto.getId(), accepterId, planCreationInput);
 
         return ResponseResult.result(result);
     }
+
+    // 나에게 신청된 점심약속 리스트 조회
+    @GetMapping("/received")
+    @ApiOperation(value = "받은 점심약속요청 조회하기", notes = "신청받은 모든 약속요청리스트를 조회합니다.")
+    public ResponseEntity<?> getPlanListReceived(
+            @RequestHeader(HttpHeaders.AUTHORIZATION) String token) {
+
+        UserDto userDto = userService.tokenValidation(token);
+
+        ServiceResult result = planService.getPlanListReceived(userDto.getId());
+
+        return ResponseResult.result(result);
+    }
+
 
     private ResponseEntity<?> errorValidation(Errors errors) {
         List<ResponseError> responseErrorList = new ArrayList<>();

--- a/src/main/java/com/grablunchtogether/dto/plan/PlanDto.java
+++ b/src/main/java/com/grablunchtogether/dto/plan/PlanDto.java
@@ -1,0 +1,37 @@
+package com.grablunchtogether.dto.plan;
+
+import com.grablunchtogether.common.enums.PlanStatus;
+import com.grablunchtogether.domain.Plan;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class PlanDto {
+
+    private long id;
+    private long requesterId;
+    private long accepterId;
+    private String planMenu;
+    private String planRestaurant;
+    private PlanStatus planStatus;
+    private LocalDateTime planTime;
+
+    public static PlanDto of(Plan plan) {
+        return PlanDto.builder()
+                .id(plan.getId())
+                .requesterId(plan.getRequester().getId())
+                .accepterId(plan.getAccepter().getId())
+                .planMenu(plan.getPlanMenu())
+                .planRestaurant(plan.getPlanRestaurant())
+                .planStatus(plan.getPlanStatus())
+                .planTime(plan.getPlanTime())
+                .build();
+    }
+}

--- a/src/main/java/com/grablunchtogether/repository/PlanRepository.java
+++ b/src/main/java/com/grablunchtogether/repository/PlanRepository.java
@@ -1,14 +1,16 @@
 package com.grablunchtogether.repository;
 
-import com.grablunchtogether.domain.Plan;
-import com.grablunchtogether.domain.User;
 import com.grablunchtogether.common.enums.PlanStatus;
+import com.grablunchtogether.domain.Plan;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
-public interface PlanRepository extends JpaRepository<Plan,Long> {
+public interface PlanRepository extends JpaRepository<Plan, Long> {
     Optional<Plan> findByRequesterIdAndAccepterIdAndPlanStatus(Long requesterId,
                                                                Long accepterId,
                                                                PlanStatus planStatus);
+
+    List<Plan> findByAccepterIdAndPlanStatus(Long userId, PlanStatus planStatus);
 }

--- a/src/main/java/com/grablunchtogether/service/plan/PlanService.java
+++ b/src/main/java/com/grablunchtogether/service/plan/PlanService.java
@@ -6,4 +6,7 @@ import com.grablunchtogether.dto.plan.PlanCreationInput;
 public interface PlanService {
     //점심약속 생성
     ServiceResult createPlan(Long id, Long accepterId, PlanCreationInput planCreationInput);
+
+    //나에게 요청된 점심약속 리스트 가져오기
+    ServiceResult getPlanListReceived(Long id);
 }

--- a/src/main/java/com/grablunchtogether/service/plan/PlanServiceImpl.java
+++ b/src/main/java/com/grablunchtogether/service/plan/PlanServiceImpl.java
@@ -1,11 +1,13 @@
 package com.grablunchtogether.service.plan;
 
+import com.grablunchtogether.common.exception.ContentNotFoundException;
 import com.grablunchtogether.common.exception.ExistingPlanException;
 import com.grablunchtogether.common.exception.UserInfoNotFoundException;
 import com.grablunchtogether.common.results.serviceResult.ServiceResult;
 import com.grablunchtogether.domain.Plan;
 import com.grablunchtogether.domain.User;
 import com.grablunchtogether.dto.plan.PlanCreationInput;
+import com.grablunchtogether.dto.plan.PlanDto;
 import com.grablunchtogether.repository.PlanRepository;
 import com.grablunchtogether.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -13,6 +15,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 import static com.grablunchtogether.common.enums.PlanStatus.REQUESTED;
 
@@ -57,5 +61,25 @@ public class PlanServiceImpl implements PlanService {
         );
 
         return ServiceResult.success("약속이 생성되었습니다.");
+    }
+
+    //나에게 요청된 점심약속 목록가져오기
+    @Override
+    public ServiceResult getPlanListReceived(Long userId) {
+
+        List<PlanDto> result = new ArrayList<>();
+
+        List<Plan> list =
+                planRepository.findByAccepterIdAndPlanStatus(userId, REQUESTED);
+
+        if (list.isEmpty()) {
+            throw new ContentNotFoundException("받은 점심약속 요청이 없습니다.");
+        }
+
+        list.forEach(plan -> {
+            result.add(PlanDto.of(plan));
+        });
+
+        return ServiceResult.success("목록 수신 성공", result);
     }
 }

--- a/src/test/java/com/grablunchtogether/service/plan/PlanListReceivedTest.java
+++ b/src/test/java/com/grablunchtogether/service/plan/PlanListReceivedTest.java
@@ -1,0 +1,105 @@
+package com.grablunchtogether.service.plan;
+
+import com.grablunchtogether.common.exception.ContentNotFoundException;
+import com.grablunchtogether.common.results.serviceResult.ServiceResult;
+import com.grablunchtogether.domain.Plan;
+import com.grablunchtogether.domain.User;
+import com.grablunchtogether.dto.plan.PlanDto;
+import com.grablunchtogether.repository.PlanRepository;
+import com.grablunchtogether.repository.UserRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.grablunchtogether.common.enums.PlanStatus.REQUESTED;
+
+class PlanListReceivedTest {
+    @Mock
+    private PlanRepository planRepository;
+    @Mock
+    private UserRepository userRepository;
+
+    private PlanService planService;
+
+    @BeforeEach
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+        planService = new PlanServiceImpl(userRepository, planRepository);
+    }
+
+    @Test
+    public void testGetListReceived_Success() {
+        //given
+        User requester = new User();
+        requester.setId(1L);
+
+        User accepter = new User();
+        accepter.setId(2L);
+
+        Plan plan1 = Plan.builder()
+                .id(1L)
+                .requester(requester)
+                .accepter(accepter)
+                .planRestaurant("a")
+                .planMenu("a")
+                .planTime(LocalDateTime.now())
+                .requestMessage("a")
+                .planStatus(REQUESTED)
+                .RegisteredAt(LocalDateTime.now())
+                .build();
+
+        Plan plan2 = Plan.builder()
+                .id(2L)
+                .requester(requester)
+                .accepter(accepter)
+                .planRestaurant("b")
+                .planMenu("b")
+                .planTime(LocalDateTime.now())
+                .requestMessage("b")
+                .planStatus(REQUESTED)
+                .RegisteredAt(LocalDateTime.now())
+                .build();
+
+        List<PlanDto> dtoList = new ArrayList<>();
+        dtoList.add(PlanDto.of(plan1));
+        dtoList.add(PlanDto.of(plan2));
+        List<Plan> list = new ArrayList<>();
+        list.add(plan1);
+        list.add(plan2);
+
+        Mockito.when(planRepository.findByAccepterIdAndPlanStatus(accepter.getId(), REQUESTED))
+                .thenReturn(list);
+        //when
+        ServiceResult result = planService.getPlanListReceived(accepter.getId());
+        //then
+        Assertions.assertThat((List<PlanDto>) result.getObject())
+                .isEqualTo(dtoList);
+    }
+
+    @Test
+    public void testGetListReceived_Fail() {
+        //given
+        User requester = new User();
+        requester.setId(1L);
+
+        User accepter = new User();
+        accepter.setId(2L);
+
+        List<Plan> list = new ArrayList<>();
+
+        Mockito.when(planRepository.findByAccepterIdAndPlanStatus(accepter.getId(), REQUESTED))
+                .thenReturn(list);
+
+        //when,then
+        Assertions.assertThatThrownBy(() -> planService.getPlanListReceived(accepter.getId()))
+                .isInstanceOf(ContentNotFoundException.class)
+                .hasMessage("받은 점심약속 요청이 없습니다.");
+    }
+}


### PR DESCRIPTION
### 추가사항
- 요청받은 점심약속리스트 조회 기능 추가
    - 사용자의 id가 Accepter로 등록되었으면서 REQUESTED 상태에 있는
      점심약속을 리스트로 조회해오고 이를 List<PlanDto>로 변환하여 리턴
      목록이 비어있을 경우 ContentNotFound 예외
##### 테스트
- [x] 테스트 코드
- [x] API 테스트