### PR TITLE
Feature/plan requested

### DIFF
--- a/src/main/java/com/grablunchtogether/controller/PlanController.java
+++ b/src/main/java/com/grablunchtogether/controller/PlanController.java
@@ -82,6 +82,18 @@ public class PlanController {
         return ResponseResult.result(result);
     }
 
+    // 내가 신청한 점심약속 리스트 조회
+    @GetMapping("/api/plan/list/requested")
+    @ApiOperation(value = "요청한 점심약속 조회하기" , notes = "내가 요청한 모든 약속리스트 조회하기")
+    public ResponseEntity<?> getPlanListIRequested(
+            @RequestHeader(HttpHeaders.AUTHORIZATION) String token) {
+
+        UserDto userDto = userService.tokenValidation(token);
+
+        ServiceResult result = planService.getPlanListIRequested(userDto.getId());
+
+        return ResponseResult.result(result);
+    }
 
     private ResponseEntity<?> errorValidation(Errors errors) {
         List<ResponseError> responseErrorList = new ArrayList<>();

--- a/src/main/java/com/grablunchtogether/repository/PlanRepository.java
+++ b/src/main/java/com/grablunchtogether/repository/PlanRepository.java
@@ -13,4 +13,6 @@ public interface PlanRepository extends JpaRepository<Plan, Long> {
                                                                PlanStatus planStatus);
 
     List<Plan> findByAccepterIdAndPlanStatus(Long userId, PlanStatus planStatus);
+
+    List<Plan> findByRequesterIdAndPlanStatusNot(Long userId, PlanStatus planStatus);
 }

--- a/src/main/java/com/grablunchtogether/service/plan/PlanService.java
+++ b/src/main/java/com/grablunchtogether/service/plan/PlanService.java
@@ -9,4 +9,7 @@ public interface PlanService {
 
     //나에게 요청된 점심약속 리스트 가져오기
     ServiceResult getPlanListReceived(Long id);
+
+    //내가 요청한 점심약속 리스트 가져오기
+    ServiceResult getPlanListIRequested(Long id);
 }

--- a/src/main/java/com/grablunchtogether/service/plan/PlanServiceImpl.java
+++ b/src/main/java/com/grablunchtogether/service/plan/PlanServiceImpl.java
@@ -18,6 +18,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.grablunchtogether.common.enums.PlanStatus.COMPLETED;
 import static com.grablunchtogether.common.enums.PlanStatus.REQUESTED;
 
 @RequiredArgsConstructor
@@ -65,6 +66,7 @@ public class PlanServiceImpl implements PlanService {
 
     //나에게 요청된 점심약속 목록가져오기
     @Override
+    @Transactional(readOnly = true)
     public ServiceResult getPlanListReceived(Long userId) {
 
         List<PlanDto> result = new ArrayList<>();
@@ -74,6 +76,26 @@ public class PlanServiceImpl implements PlanService {
 
         if (list.isEmpty()) {
             throw new ContentNotFoundException("받은 점심약속 요청이 없습니다.");
+        }
+
+        list.forEach(plan -> {
+            result.add(PlanDto.of(plan));
+        });
+
+        return ServiceResult.success("목록 수신 성공", result);
+    }
+
+    //내가 요청한 점심약속 목록 조회
+    @Override
+    @Transactional(readOnly = true)
+    public ServiceResult getPlanListIRequested(Long userId) {
+        List<PlanDto> result = new ArrayList<>();
+
+        List<Plan> list =
+                planRepository.findByRequesterIdAndPlanStatusNot(userId,COMPLETED);
+
+        if (list.isEmpty()) {
+            throw new ContentNotFoundException("요청한 점심식사 요청이 없습니다.");
         }
 
         list.forEach(plan -> {

--- a/src/test/java/com/grablunchtogether/service/plan/PlanGetListIRequestedTest.java
+++ b/src/test/java/com/grablunchtogether/service/plan/PlanGetListIRequestedTest.java
@@ -1,0 +1,105 @@
+package com.grablunchtogether.service.plan;
+
+import com.grablunchtogether.common.exception.ContentNotFoundException;
+import com.grablunchtogether.common.results.serviceResult.ServiceResult;
+import com.grablunchtogether.domain.Plan;
+import com.grablunchtogether.domain.User;
+import com.grablunchtogether.dto.plan.PlanDto;
+import com.grablunchtogether.repository.PlanRepository;
+import com.grablunchtogether.repository.UserRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.grablunchtogether.common.enums.PlanStatus.COMPLETED;
+import static com.grablunchtogether.common.enums.PlanStatus.REQUESTED;
+
+class PlanGetListIRequestedTest {
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private PlanRepository planRepository;
+
+    private PlanService planService;
+
+    @BeforeEach
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+        planService = new PlanServiceImpl(userRepository, planRepository);
+    }
+    @Test
+    public void testGetPlanListIRequested_Success() {
+        //given
+        User requester = new User();
+        requester.setId(1L);
+
+        User accepter = new User();
+        accepter.setId(2L);
+
+        Plan plan1 = Plan.builder()
+                .id(1L)
+                .requester(requester)
+                .accepter(accepter)
+                .planRestaurant("a")
+                .planMenu("a")
+                .planTime(LocalDateTime.now())
+                .requestMessage("a")
+                .planStatus(REQUESTED)
+                .RegisteredAt(LocalDateTime.now())
+                .build();
+
+        Plan plan2 = Plan.builder()
+                .id(2L)
+                .requester(requester)
+                .accepter(accepter)
+                .planRestaurant("b")
+                .planMenu("b")
+                .planTime(LocalDateTime.now())
+                .requestMessage("b")
+                .planStatus(REQUESTED)
+                .RegisteredAt(LocalDateTime.now())
+                .build();
+
+        List<PlanDto> dtoList = new ArrayList<>();
+        dtoList.add(PlanDto.of(plan1));
+        dtoList.add(PlanDto.of(plan2));
+        List<Plan> list = new ArrayList<>();
+        list.add(plan1);
+        list.add(plan2);
+
+        Mockito.when(planRepository.findByRequesterIdAndPlanStatusNot(requester.getId(), COMPLETED))
+                .thenReturn(list);
+        //when
+        ServiceResult result = planService.getPlanListIRequested(requester.getId());
+        //then
+        Assertions.assertThat((List<PlanDto>) result.getObject())
+                .isEqualTo(dtoList);
+    }
+    @Test
+    public void testGetPlanListIRequested_Fail() {
+        //given
+        User requester = new User();
+        requester.setId(1L);
+
+        User accepter = new User();
+        accepter.setId(2L);
+
+        List<Plan> list = new ArrayList<>();
+
+        Mockito.when(planRepository.findByRequesterIdAndPlanStatusNot(requester.getId(), COMPLETED))
+                .thenReturn(list);
+
+        //when,then
+        Assertions.assertThatThrownBy(()->planService.getPlanListIRequested(requester.getId()))
+                .isInstanceOf(ContentNotFoundException.class)
+                .hasMessage("요청한 점심식사 요청이 없습니다.");
+    }
+}


### PR DESCRIPTION
### 추가사항

- 요청한 점심약속리스트 조회 기능 추가
    - 사용자가 요청한 점심약속을 조회하는 기능 추가
    - 사용자의 id가 Requester로 등록되었으면서 COMPLETED 상태에 있지 않은
      (CANCELED,REQUESTED,ACCEPTED,REJECTED,EXPIRED)
      점심약속을 리스트로 조회해오고 이를 List<PlanDto>로 변환하여 리턴
      목록이 비어있을 경우 ContentNotFound 예외

##### 테스트
- [x] 테스트 코드
- [x] API 테스트