### PR TITLE
Feature/plan approval

### DIFF
--- a/src/main/java/com/grablunchtogether/common/exception/AuthorityException.java
+++ b/src/main/java/com/grablunchtogether/common/exception/AuthorityException.java
@@ -1,0 +1,7 @@
+package com.grablunchtogether.common.exception;
+
+public class AuthorityException extends RuntimeException {
+    public AuthorityException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/grablunchtogether/common/exception/globalExceptionHandler/GlobalExceptionHandler.java
+++ b/src/main/java/com/grablunchtogether/common/exception/globalExceptionHandler/GlobalExceptionHandler.java
@@ -44,5 +44,11 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     public ResponseEntity<String> ExistingPlanExceptionHandler(ExistingPlanException exception) {
         return new ResponseEntity<>(exception.getMessage(), HttpStatus.BAD_REQUEST);
     }
+
+    //Exception 핸들러(이미 수락/거절/만료 된 점심약속의 상태를 변경하려고 할 경우)
+    @ExceptionHandler(AuthorityException.class)
+    public ResponseEntity<String> AuthorityExceptionHandler(AuthorityException exception) {
+        return new ResponseEntity<>(exception.getMessage(), HttpStatus.BAD_REQUEST);
+    }
 }
 

--- a/src/main/java/com/grablunchtogether/controller/PlanController.java
+++ b/src/main/java/com/grablunchtogether/controller/PlanController.java
@@ -95,6 +95,22 @@ public class PlanController {
         return ResponseResult.result(result);
     }
 
+    // 점심약속 업데이트(1) - 거절 / 승낙 (상태업데이트)
+    @PatchMapping("/api/plan/accept/{planId}/{acceptCode}")
+    @ApiOperation(value = "점심약속 수락/거절 하기" , notes = "내가 받은 점심약속 수락/거절하기")
+    public ResponseEntity<?> approvePlanRequest(
+            @PathVariable Long planId,
+            @PathVariable Character acceptCode,
+            @RequestHeader("Authorization") String token) {
+
+        UserDto userDto = userService.tokenValidation(token);
+        ServiceResult result = planService.approvePlan(userDto.getId(), planId, acceptCode);
+
+        return ResponseResult.result(result);
+    }
+
+
+
     private ResponseEntity<?> errorValidation(Errors errors) {
         List<ResponseError> responseErrorList = new ArrayList<>();
         if (errors.hasErrors()) {

--- a/src/main/java/com/grablunchtogether/domain/Plan.java
+++ b/src/main/java/com/grablunchtogether/domain/Plan.java
@@ -10,6 +10,9 @@ import org.springframework.format.annotation.DateTimeFormat;
 import javax.persistence.*;
 import java.time.LocalDateTime;
 
+import static com.grablunchtogether.common.enums.PlanStatus.ACCEPTED;
+import static com.grablunchtogether.common.enums.PlanStatus.REJECTED;
+
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
@@ -49,5 +52,8 @@ public class Plan {
     @Column
     private LocalDateTime RegisteredAt;
 
-
+    // 수락/ 거절을 위한 메서드
+    public void approve(Character approvalCode){
+        this.planStatus = approvalCode == 'Y' ? ACCEPTED : REJECTED;
+    }
 }

--- a/src/main/java/com/grablunchtogether/repository/PlanRepository.java
+++ b/src/main/java/com/grablunchtogether/repository/PlanRepository.java
@@ -15,4 +15,6 @@ public interface PlanRepository extends JpaRepository<Plan, Long> {
     List<Plan> findByAccepterIdAndPlanStatus(Long userId, PlanStatus planStatus);
 
     List<Plan> findByRequesterIdAndPlanStatusNot(Long userId, PlanStatus planStatus);
+
+    Optional<Plan> findByIdAndAccepterId(Long planId, Long userId);
 }

--- a/src/main/java/com/grablunchtogether/service/plan/PlanService.java
+++ b/src/main/java/com/grablunchtogether/service/plan/PlanService.java
@@ -12,4 +12,7 @@ public interface PlanService {
 
     //내가 요청한 점심약속 리스트 가져오기
     ServiceResult getPlanListIRequested(Long id);
+
+    //요청받은 점심약속을 수락 또는 거절
+    ServiceResult approvePlan(Long id, Long planId, Character acceptCode);
 }

--- a/src/test/java/com/grablunchtogether/service/plan/PlanApprovalTest.java
+++ b/src/test/java/com/grablunchtogether/service/plan/PlanApprovalTest.java
@@ -1,0 +1,135 @@
+package com.grablunchtogether.service.plan;
+
+import com.grablunchtogether.common.exception.AuthorityException;
+import com.grablunchtogether.common.exception.ContentNotFoundException;
+import com.grablunchtogether.common.results.serviceResult.ServiceResult;
+import com.grablunchtogether.domain.Plan;
+import com.grablunchtogether.domain.User;
+import com.grablunchtogether.repository.PlanRepository;
+import com.grablunchtogether.repository.UserRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static com.grablunchtogether.common.enums.PlanStatus.*;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+class PlanApprovalTest {
+
+    @Mock
+    private PlanRepository planRepository;
+    @Mock
+    private UserRepository userRepository;
+    private PlanService planService;
+
+    @BeforeEach
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+        planService = new PlanServiceImpl(userRepository, planRepository);
+    }
+
+    @Test
+    public void TestPlanApproval_Success() {
+        //given
+        User requester = new User();
+        requester.setId(1L);
+        User accepter = new User();
+        accepter.setId(2L);
+
+        Plan plan1 = Plan.builder()
+                .id(1L)
+                .requester(requester)
+                .accepter(accepter)
+                .planRestaurant("a")
+                .planMenu("a")
+                .planTime(LocalDateTime.now())
+                .requestMessage("a")
+                .planStatus(REQUESTED)
+                .RegisteredAt(LocalDateTime.now())
+                .build();
+
+        Plan plan2 = Plan.builder()
+                .id(1L)
+                .requester(accepter)
+                .accepter(requester)
+                .planRestaurant("a")
+                .planMenu("a")
+                .planTime(LocalDateTime.now())
+                .requestMessage("a")
+                .planStatus(REQUESTED)
+                .RegisteredAt(LocalDateTime.now())
+                .build();
+
+        Mockito.when(planRepository.findByIdAndAccepterId(1L, accepter.getId()))
+                .thenReturn(Optional.of(plan1));
+        Mockito.when(planRepository.findByIdAndAccepterId(1L, requester.getId()))
+                .thenReturn(Optional.of(plan2));
+
+
+        //when
+        ServiceResult y = planService.approvePlan(accepter.getId(), plan1.getId(), 'Y');
+        ServiceResult n = planService.approvePlan(requester.getId(), plan2.getId(), 'N');
+
+        //then
+        Assertions.assertThat(y.isResult()).isTrue();
+        Assertions.assertThat(n.isResult()).isTrue();
+        assertThat(plan1.getPlanStatus()).isEqualTo(ACCEPTED);
+        assertThat(plan2.getPlanStatus()).isEqualTo(REJECTED);
+    }
+
+    @Test
+    public void TestPlanApproval_Fail_EmptyPlan() {
+        //given
+
+        User accepter = new User();
+        accepter.setId(2L);
+
+        Plan plan = Plan.builder().id(1L).build();
+
+
+        Mockito.when(planRepository.findByIdAndAccepterId(1L, accepter.getId()))
+                .thenReturn(Optional.empty());
+
+        //when,then
+        Assertions
+                .assertThatThrownBy(() -> planService.approvePlan(accepter.getId(), plan.getId(), 'Y'))
+                .isInstanceOf(ContentNotFoundException.class)
+                .hasMessage("존재하지 않는 점심약속이거나 나에게 요청된 약속이 아닙니다.");
+    }
+
+    @Test
+    public void TestPlanApproval_Fail_AlreadyDone() {
+        //given
+        User requester = new User();
+        requester.setId(1L);
+        User accepter = new User();
+        accepter.setId(2L);
+
+        Plan plan1 = Plan.builder()
+                .id(1L)
+                .requester(requester)
+                .accepter(accepter)
+                .planRestaurant("a")
+                .planMenu("a")
+                .planTime(LocalDateTime.now())
+                .requestMessage("a")
+                .planStatus(ACCEPTED)
+                .RegisteredAt(LocalDateTime.now())
+                .build();
+
+        Mockito.when(planRepository.findByIdAndAccepterId(1L, accepter.getId()))
+                .thenReturn(Optional.of(plan1));
+
+        //when,then
+        Assertions
+                .assertThatThrownBy(() -> planService.approvePlan(accepter.getId(), plan1.getId(), 'Y'))
+                .isInstanceOf(AuthorityException.class)
+                .hasMessage("이미 수락 또는 거절/만료 된 약속입니다.");
+    }
+}


### PR DESCRIPTION
### 추가사항
- 받은 점심식사요청 수락 / 거절하는 기능 추가
    - 선택한 점심약속이 존재하는지, 내가 피신청자가 맞는지 확인
    - 사용자의 id가 Accepter로 등록되었으면서 REQUEST 상태인
      점심약속이라면, Plan의 approve()메서드를 사용해 상태업데이트
    - 점심약속이 존재하지 않거나 내가 수락자가 아닌경우 -> ContentNotFoundException
    - 점심약속이 존재하나 상태가 REQUEST가 아닐경우 -> AuthorityException
- AuthorityException 예외 추가
##### 테스트
- [x] 테스트 코드
- [x] API 테스트