### PR TITLE
Feature/plan cancellation

### DIFF
--- a/src/main/java/com/grablunchtogether/controller/PlanController.java
+++ b/src/main/java/com/grablunchtogether/controller/PlanController.java
@@ -84,7 +84,7 @@ public class PlanController {
 
     // 내가 신청한 점심약속 리스트 조회
     @GetMapping("/api/plan/list/requested")
-    @ApiOperation(value = "요청한 점심약속 조회하기" , notes = "내가 요청한 모든 약속리스트 조회하기")
+    @ApiOperation(value = "요청한 점심약속 조회하기", notes = "내가 요청한 모든 약속리스트 조회하기")
     public ResponseEntity<?> getPlanListIRequested(
             @RequestHeader(HttpHeaders.AUTHORIZATION) String token) {
 
@@ -97,11 +97,11 @@ public class PlanController {
 
     // 점심약속 업데이트(1) - 거절 / 승낙 (상태업데이트)
     @PatchMapping("/api/plan/accept/{planId}/{acceptCode}")
-    @ApiOperation(value = "점심약속 수락/거절 하기" , notes = "내가 받은 점심약속 수락/거절하기")
+    @ApiOperation(value = "점심약속 수락/거절 하기", notes = "내가 받은 점심약속 수락/거절하기")
     public ResponseEntity<?> approvePlanRequest(
             @PathVariable Long planId,
             @PathVariable Character acceptCode,
-            @RequestHeader("Authorization") String token) {
+            @RequestHeader(HttpHeaders.AUTHORIZATION) String token) {
 
         UserDto userDto = userService.tokenValidation(token);
         ServiceResult result = planService.approvePlan(userDto.getId(), planId, acceptCode);
@@ -109,6 +109,19 @@ public class PlanController {
         return ResponseResult.result(result);
     }
 
+    // 점심약속 업데이트(2) - 취소(상태업데이트)
+    @PatchMapping("/api/plan/cancel/{planId}")
+    @ApiOperation(value = "점심약속 취소 하기", notes = "수락된 점심약속 취소하기")
+    public ResponseEntity<?> cancelPlanRequest(
+            @PathVariable Long planId,
+            @RequestHeader(HttpHeaders.AUTHORIZATION) String token) {
+
+        UserDto userDto = userService.tokenValidation(token);
+
+        ServiceResult result = planService.cancelPlan(userDto.getId(), planId);
+
+        return ResponseResult.result(result);
+    }
 
 
     private ResponseEntity<?> errorValidation(Errors errors) {

--- a/src/main/java/com/grablunchtogether/domain/Plan.java
+++ b/src/main/java/com/grablunchtogether/domain/Plan.java
@@ -10,8 +10,7 @@ import org.springframework.format.annotation.DateTimeFormat;
 import javax.persistence.*;
 import java.time.LocalDateTime;
 
-import static com.grablunchtogether.common.enums.PlanStatus.ACCEPTED;
-import static com.grablunchtogether.common.enums.PlanStatus.REJECTED;
+import static com.grablunchtogether.common.enums.PlanStatus.*;
 
 @Getter
 @AllArgsConstructor
@@ -55,5 +54,8 @@ public class Plan {
     // 수락/ 거절을 위한 메서드
     public void approve(Character approvalCode){
         this.planStatus = approvalCode == 'Y' ? ACCEPTED : REJECTED;
+    }
+    public void cancel(){
+        this.planStatus = CANCELED;
     }
 }

--- a/src/main/java/com/grablunchtogether/service/plan/PlanService.java
+++ b/src/main/java/com/grablunchtogether/service/plan/PlanService.java
@@ -15,4 +15,7 @@ public interface PlanService {
 
     //요청받은 점심약속을 수락 또는 거절
     ServiceResult approvePlan(Long id, Long planId, Character acceptCode);
+
+    //수락된 점심약속을 취소
+    ServiceResult cancelPlan(Long id, Long planId);
 }

--- a/src/test/java/com/grablunchtogether/service/plan/PlanCancelTest.java
+++ b/src/test/java/com/grablunchtogether/service/plan/PlanCancelTest.java
@@ -1,0 +1,117 @@
+package com.grablunchtogether.service.plan;
+
+import com.grablunchtogether.common.exception.AuthorityException;
+import com.grablunchtogether.common.results.serviceResult.ServiceResult;
+import com.grablunchtogether.domain.Plan;
+import com.grablunchtogether.domain.User;
+import com.grablunchtogether.repository.PlanRepository;
+import com.grablunchtogether.repository.UserRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static com.grablunchtogether.common.enums.PlanStatus.*;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+class PlanCancelTest {
+    @Mock
+    private PlanRepository planRepository;
+    @Mock
+    private UserRepository userRepository;
+    private PlanService planService;
+
+    @BeforeEach
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+        planService = new PlanServiceImpl(userRepository, planRepository);
+    }
+
+    @Test
+    public void TestPlanApproval_Success() {
+        //given
+        User requester = User.builder().id(1L).build();
+        User accepter = User.builder().id(2L).build();
+
+        Plan plan1 = Plan.builder()
+                .id(1L)
+                .requester(requester)
+                .accepter(accepter)
+                .planRestaurant("a")
+                .planMenu("a")
+                .planTime(LocalDateTime.now())
+                .requestMessage("a")
+                .planStatus(ACCEPTED)
+                .RegisteredAt(LocalDateTime.now())
+                .build();
+
+        Mockito.when(planRepository.findById(plan1.getId()))
+                .thenReturn(Optional.of(plan1));
+
+        //when
+        ServiceResult result = planService.cancelPlan(accepter.getId(), plan1.getId());
+
+        //then
+        Assertions.assertThat(result.isResult()).isTrue();
+        assertThat(plan1.getPlanStatus()).isEqualTo(CANCELED);
+    }
+
+    @Test
+    public void TestPlanApproval_Fail_NotInvolved() {
+        //given
+        User requester = User.builder().id(1L).build();
+        User accepter = User.builder().id(2L).build();
+
+        Plan plan2 = Plan.builder()
+                .id(2L)
+                .requester(User.builder().id(9L).build())
+                .accepter(User.builder().id(10L).build())
+                .planRestaurant("a")
+                .planMenu("a")
+                .planTime(LocalDateTime.now())
+                .requestMessage("a")
+                .planStatus(ACCEPTED)
+                .RegisteredAt(LocalDateTime.now())
+                .build();
+
+        Mockito.when(planRepository.findById(plan2.getId()))
+                .thenReturn(Optional.of(plan2));
+
+        //when,then
+        Assertions.assertThatThrownBy(() -> planService.cancelPlan(accepter.getId(), plan2.getId()))
+                .isInstanceOf(AuthorityException.class)
+                .hasMessage("본인이 요청/수신 한 점심약속 만 취소할 수 있습니다.");
+    }
+
+    @Test
+    public void TestPlanApproval_Fail_NotAccepted() {
+        //given
+        User requester = User.builder().id(1L).build();
+        User accepter = User.builder().id(2L).build();
+
+        Plan plan1 = Plan.builder()
+                .id(1L)
+                .requester(requester)
+                .accepter(accepter)
+                .planRestaurant("a")
+                .planMenu("a")
+                .planTime(LocalDateTime.now())
+                .requestMessage("a")
+                .planStatus(REQUESTED)
+                .RegisteredAt(LocalDateTime.now())
+                .build();
+
+        Mockito.when(planRepository.findById(plan1.getId()))
+                .thenReturn(Optional.of(plan1));
+
+        //when,then
+        Assertions.assertThatThrownBy(() -> planService.cancelPlan(requester.getId(), plan1.getId()))
+                .isInstanceOf(AuthorityException.class)
+                .hasMessage("이미 취소 되었거나 취소할 수 없는상태의 점심약속입니다.");
+    }
+}


### PR DESCRIPTION
### 추가사항
- 수락된 상태의 내가 연관된(신청/피신청) 점심식사 취소 기능 추가
    - 선택한 점심약속이 존재하는지, 내가 연관된 점심약속이 맞는지 확인
    - 사용자의 id가 Accepter 또는 Requester 로 등록되었으면서 Accepted 상태인
      점심약속이라면, Plan의 cancel()메서드를 사용해 CANCELED 상태로 업데이트
    - 내가 연관된 점심약속이 아닌경우 -> AuthorityException 예외
    - 점심약속이 존재하나 상태가 ACCEPTED가 아닐경우 -> AuthorityException 예외
##### 테스트
- [x] 테스트 코드
- [x] API 테스트