### PR TITLE
Feature/plan modification

### DIFF
--- a/src/main/java/com/grablunchtogether/controller/PlanController.java
+++ b/src/main/java/com/grablunchtogether/controller/PlanController.java
@@ -123,6 +123,21 @@ public class PlanController {
         return ResponseResult.result(result);
     }
 
+    @PatchMapping("/api/plan/edit/{planId}")
+    @ApiOperation(value = "점심약속 수정 하기", notes = "수락된 점심약속 취소하기")
+    public ResponseEntity<?> editPlanRequest(
+            @PathVariable Long planId,
+            @RequestHeader("Authorization") String token,
+            @RequestBody PlanCreationInput planModificationInput) {
+
+        UserDto userDto = userService.tokenValidation(token);
+
+        ServiceResult result =
+                planService.editPlanRequest(userDto.getId(), planId, planModificationInput);
+
+        return ResponseResult.result(result);
+    }
+
 
     private ResponseEntity<?> errorValidation(Errors errors) {
         List<ResponseError> responseErrorList = new ArrayList<>();

--- a/src/main/java/com/grablunchtogether/domain/Plan.java
+++ b/src/main/java/com/grablunchtogether/domain/Plan.java
@@ -52,10 +52,19 @@ public class Plan {
     private LocalDateTime RegisteredAt;
 
     // 수락/ 거절을 위한 메서드
-    public void approve(Character approvalCode){
+    public void approve(Character approvalCode) {
         this.planStatus = approvalCode == 'Y' ? ACCEPTED : REJECTED;
     }
-    public void cancel(){
+
+    public void cancel() {
         this.planStatus = CANCELED;
+    }
+
+    public void update(String planMenu, String planRestaurant, LocalDateTime planTime,
+                       String requestMessage) {
+        this.planMenu = planMenu;
+        this.planRestaurant = planRestaurant;
+        this.planTime = planTime;
+        this.requestMessage = requestMessage;
     }
 }

--- a/src/main/java/com/grablunchtogether/service/plan/PlanService.java
+++ b/src/main/java/com/grablunchtogether/service/plan/PlanService.java
@@ -18,4 +18,7 @@ public interface PlanService {
 
     //수락된 점심약속을 취소
     ServiceResult cancelPlan(Long id, Long planId);
+
+    //요청중인 상태의 점심약속을 수정
+    ServiceResult editPlanRequest(Long id, Long planId, PlanCreationInput planModificationInput);
 }

--- a/src/main/java/com/grablunchtogether/service/plan/PlanServiceImpl.java
+++ b/src/main/java/com/grablunchtogether/service/plan/PlanServiceImpl.java
@@ -149,4 +149,32 @@ public class PlanServiceImpl implements PlanService {
 
         return ServiceResult.success("점심약속요청이 취소되었습니다.");
     }
+
+    //내가 요청한 점심약속 수정
+    @Override
+    @Transactional
+    public ServiceResult editPlanRequest(Long userId,
+                                         Long planId,
+                                         PlanCreationInput planModificationInput) {
+
+        Plan plan = planRepository.findById(planId)
+                .orElseThrow(() -> new ContentNotFoundException("존재하지 않는 약속 신청입니다."));
+
+        if (!Objects.equals(plan.getRequester().getId(), userId)) {
+            throw new AuthorityException("내가 신청한 약속만 수정할 수 있습니다.");
+        }
+
+        if (!Objects.equals(plan.getPlanStatus(), REQUESTED)) {
+            throw new AuthorityException("요청중인 상태의 점심약속만 수정할 수 있습니다.");
+        }
+
+        plan.update(planModificationInput.getPlanMenu(),
+                planModificationInput.getPlanRestaurant(),
+                planModificationInput.getPlanTime(),
+                planModificationInput.getRequestMessage());
+
+        planRepository.save(plan);
+
+        return ServiceResult.success("점심약속 요청 수정이 완료되었습니다.");
+    }
 }

--- a/src/test/java/com/grablunchtogether/service/plan/PlanEditTest.java
+++ b/src/test/java/com/grablunchtogether/service/plan/PlanEditTest.java
@@ -1,0 +1,155 @@
+package com.grablunchtogether.service.plan;
+
+import com.grablunchtogether.common.exception.AuthorityException;
+import com.grablunchtogether.common.results.serviceResult.ServiceResult;
+import com.grablunchtogether.domain.Plan;
+import com.grablunchtogether.domain.User;
+import com.grablunchtogether.dto.plan.PlanCreationInput;
+import com.grablunchtogether.repository.PlanRepository;
+import com.grablunchtogether.repository.UserRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static com.grablunchtogether.common.enums.PlanStatus.COMPLETED;
+import static com.grablunchtogether.common.enums.PlanStatus.REQUESTED;
+
+class PlanEditTest {
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private PlanRepository planRepository;
+
+    private PlanService planService;
+
+    @BeforeEach
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+        planService = new PlanServiceImpl(userRepository, planRepository);
+    }
+
+    @Test
+    public void TestEditPlan_Success() {
+        //given
+        User requester = new User();
+        requester.setId(1L);
+
+        User accepter = new User();
+        accepter.setId(2L);
+
+        Plan plan = Plan.builder()
+                .id(1L)
+                .requester(requester)
+                .accepter(accepter)
+                .planRestaurant("a")
+                .planMenu("a")
+                .planTime(LocalDateTime.now())
+                .requestMessage("a")
+                .planStatus(REQUESTED)
+                .RegisteredAt(LocalDateTime.now())
+                .build();
+
+        PlanCreationInput planModificationInput =
+                PlanCreationInput.builder()
+                        .planRestaurant("aa")
+                        .planMenu("ss")
+                        .planTime(LocalDateTime.now())
+                        .requestMessage("123123")
+                        .build();
+
+        Mockito.when(planRepository.findById(requester.getId()))
+                .thenReturn(Optional.of(plan));
+
+        //when
+        ServiceResult result = planService.editPlanRequest(requester.getId(), plan.getId(), planModificationInput);
+
+        //then
+        Assertions.assertThat(result.isResult()).isTrue();
+        Assertions.assertThat(plan.getRequestMessage()).isEqualTo("123123");
+    }
+
+    @Test
+    public void TestEditPlan_Fail_AlreadyDone() {
+        //given
+        User requester = new User();
+        requester.setId(1L);
+
+        User accepter = new User();
+        accepter.setId(2L);
+
+        Plan plan = Plan.builder()
+                .id(1L)
+                .requester(requester)
+                .accepter(accepter)
+                .planRestaurant("a")
+                .planMenu("a")
+                .planTime(LocalDateTime.now())
+                .requestMessage("a")
+                .planStatus(COMPLETED)
+                .RegisteredAt(LocalDateTime.now())
+                .build();
+
+        PlanCreationInput planModificationInput =
+                PlanCreationInput.builder()
+                        .planRestaurant("aa")
+                        .planMenu("ss")
+                        .planTime(LocalDateTime.now())
+                        .requestMessage("123123")
+                        .build();
+
+        Mockito.when(planRepository.findById(requester.getId()))
+                .thenReturn(Optional.of(plan));
+
+        //when,then
+        Assertions.assertThatThrownBy(() ->
+                        planService.editPlanRequest(requester.getId(), plan.getId(), planModificationInput))
+                .isInstanceOf(AuthorityException.class)
+                .hasMessage("요청중인 상태의 점심약속만 수정할 수 있습니다.");
+    }
+
+    @Test
+    public void TestEditPlan_Fail_NotMyPlan() {
+        //given
+        User requester = new User();
+        requester.setId(1L);
+
+        User accepter = new User();
+        accepter.setId(2L);
+
+        Plan plan = Plan.builder()
+                .id(1L)
+                .requester(accepter)
+                .accepter(requester)
+                .planRestaurant("a")
+                .planMenu("a")
+                .planTime(LocalDateTime.now())
+                .requestMessage("a")
+                .planStatus(COMPLETED)
+                .RegisteredAt(LocalDateTime.now())
+                .build();
+
+        PlanCreationInput planModificationInput =
+                PlanCreationInput.builder()
+                        .planRestaurant("aa")
+                        .planMenu("ss")
+                        .planTime(LocalDateTime.now())
+                        .requestMessage("123123")
+                        .build();
+
+        Mockito.when(planRepository.findById(requester.getId()))
+                .thenReturn(Optional.of(plan));
+
+        //when,then
+        Assertions.assertThatThrownBy(() ->
+                        planService.editPlanRequest(requester.getId(), plan.getId(), planModificationInput))
+                .isInstanceOf(AuthorityException.class)
+                .hasMessage("내가 신청한 약속만 수정할 수 있습니다.");
+    }
+}


### PR DESCRIPTION
### 추가사항
- 내가 신청한 점심약속 수정 기능 추가
    - 선택한 점심약속이 존재하는지, 내가 신청한 점심약속이 맞는지 확인
    - 사용자의 id가 Requester 로 등록되었으면서 REQUESTED 상태인
      점심약속이라면, Plan의 update()메서드를 사용해 신청내용 업데이트
    - 내가 신청한 점심약속이 아닌경우 -> AuthorityException 예외
    - 상태가 REQUESTED 가 아닐경우 -> AuthorityException 예외

##### 테스트
- [x] 테스트 코드
- [x] API 테스트