### PR TITLE
Feature/plan deletion

### DIFF
--- a/src/main/java/com/grablunchtogether/common/exception/PlanTimeNotMatchedException.java
+++ b/src/main/java/com/grablunchtogether/common/exception/PlanTimeNotMatchedException.java
@@ -1,0 +1,7 @@
+package com.grablunchtogether.common.exception;
+
+public class PlanTimeNotMatchedException extends RuntimeException {
+    public PlanTimeNotMatchedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/grablunchtogether/common/exception/globalExceptionHandler/GlobalExceptionHandler.java
+++ b/src/main/java/com/grablunchtogether/common/exception/globalExceptionHandler/GlobalExceptionHandler.java
@@ -50,5 +50,11 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     public ResponseEntity<String> AuthorityExceptionHandler(AuthorityException exception) {
         return new ResponseEntity<>(exception.getMessage(), HttpStatus.BAD_REQUEST);
     }
+
+    //Exception 핸들러(이미 수락/거절/만료 된 점심약속의 상태를 변경하려고 할 경우)
+    @ExceptionHandler(PlanTimeNotMatchedException.class)
+    public ResponseEntity<String> PlanTimeNotMatchedExceptionHandler(PlanTimeNotMatchedException exception) {
+        return new ResponseEntity<>(exception.getMessage(), HttpStatus.BAD_REQUEST);
+    }
 }
 

--- a/src/main/java/com/grablunchtogether/controller/PlanController.java
+++ b/src/main/java/com/grablunchtogether/controller/PlanController.java
@@ -127,7 +127,7 @@ public class PlanController {
     @ApiOperation(value = "점심약속 수정 하기", notes = "수락된 점심약속 취소하기")
     public ResponseEntity<?> editPlanRequest(
             @PathVariable Long planId,
-            @RequestHeader("Authorization") String token,
+            @RequestHeader(HttpHeaders.AUTHORIZATION) String token,
             @RequestBody PlanCreationInput planModificationInput) {
 
         UserDto userDto = userService.tokenValidation(token);
@@ -138,7 +138,19 @@ public class PlanController {
         return ResponseResult.result(result);
     }
 
+    // 점심약속 삭제
+    @DeleteMapping("/api/plan/delete/{planId}")
+    @ApiOperation(value = "점심약속 삭제 하기", notes = "요청상태의 점심약속 삭제하기")
+    public ResponseEntity<?> deletePlanRequest(
+            @PathVariable Long planId,
+            @RequestHeader(HttpHeaders.AUTHORIZATION) String token) {
 
+        UserDto userDto = userService.tokenValidation(token);
+
+        ServiceResult result = planService.planDeletion(userDto.getId(), planId);
+
+        return ResponseResult.result(result);
+    }
     private ResponseEntity<?> errorValidation(Errors errors) {
         List<ResponseError> responseErrorList = new ArrayList<>();
         if (errors.hasErrors()) {

--- a/src/main/java/com/grablunchtogether/service/plan/PlanService.java
+++ b/src/main/java/com/grablunchtogether/service/plan/PlanService.java
@@ -21,4 +21,7 @@ public interface PlanService {
 
     //요청중인 상태의 점심약속을 수정
     ServiceResult editPlanRequest(Long id, Long planId, PlanCreationInput planModificationInput);
+
+    //요청중인 상태의 점심약속을 삭제
+    ServiceResult planDeletion(Long id, Long planId);
 }

--- a/src/test/java/com/grablunchtogether/service/plan/PlanDeleteTest.java
+++ b/src/test/java/com/grablunchtogether/service/plan/PlanDeleteTest.java
@@ -1,0 +1,161 @@
+package com.grablunchtogether.service.plan;
+
+import com.grablunchtogether.common.exception.AuthorityException;
+import com.grablunchtogether.common.exception.PlanTimeNotMatchedException;
+import com.grablunchtogether.common.results.serviceResult.ServiceResult;
+import com.grablunchtogether.domain.Plan;
+import com.grablunchtogether.domain.User;
+import com.grablunchtogether.repository.PlanRepository;
+import com.grablunchtogether.repository.UserRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static com.grablunchtogether.common.enums.PlanStatus.COMPLETED;
+import static com.grablunchtogether.common.enums.PlanStatus.REQUESTED;
+
+class PlanDeleteTest {
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private PlanRepository planRepository;
+
+    private PlanService planService;
+
+    @BeforeEach
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+        planService = new PlanServiceImpl(userRepository, planRepository);
+    }
+
+    @Test
+    public void TestDeletePlan_Success() {
+        //given
+        User requester = new User();
+        requester.setId(1L);
+
+        User accepter = new User();
+        accepter.setId(2L);
+
+        Plan plan = Plan.builder()
+                .id(1L)
+                .requester(requester)
+                .accepter(accepter)
+                .planRestaurant("a")
+                .planMenu("a")
+                .planTime(LocalDateTime.parse("2023-09-01T11:00"))
+                .requestMessage("a")
+                .planStatus(REQUESTED)
+                .RegisteredAt(LocalDateTime.now())
+                .build();
+
+        Mockito.when(planRepository.findById(requester.getId()))
+                .thenReturn(Optional.of(plan));
+
+        //when
+        ServiceResult result = planService.planDeletion(requester.getId(), plan.getId());
+
+        //then
+        Assertions.assertThat(result.isResult()).isTrue();
+    }
+
+    @Test
+    public void TestDeletePlan_Fail_AlreadyDone() {
+        //given
+        User requester = new User();
+        requester.setId(1L);
+
+        User accepter = new User();
+        accepter.setId(2L);
+
+        Plan plan = Plan.builder()
+                .id(1L)
+                .requester(requester)
+                .accepter(accepter)
+                .planRestaurant("a")
+                .planMenu("a")
+                .planTime(LocalDateTime.now())
+                .requestMessage("a")
+                .planStatus(COMPLETED)
+                .RegisteredAt(LocalDateTime.now())
+                .build();
+
+        Mockito.when(planRepository.findById(plan.getId()))
+                .thenReturn(Optional.of(plan));
+
+        //when,then
+        Assertions.assertThatThrownBy(() ->
+                        planService.planDeletion(requester.getId(), plan.getId()))
+                .isInstanceOf(AuthorityException.class)
+                .hasMessage("이미 수락 또는 거절된 점심약속은 삭제할 수 없습니다. 점심약속 취소를 진행 해주세요.");
+    }
+
+    @Test
+    public void TestDeletePlan_Fail_NotMyPlan() {
+        //given
+        User requester = new User();
+        requester.setId(1L);
+
+        User accepter = new User();
+        accepter.setId(2L);
+
+        Plan plan = Plan.builder()
+                .id(1L)
+                .requester(accepter)
+                .accepter(requester)
+                .planRestaurant("a")
+                .planMenu("a")
+                .planTime(LocalDateTime.now())
+                .requestMessage("a")
+                .planStatus(COMPLETED)
+                .RegisteredAt(LocalDateTime.now())
+                .build();
+
+        Mockito.when(planRepository.findById(plan.getId()))
+                .thenReturn(Optional.of(plan));
+
+        //when,then
+        Assertions.assertThatThrownBy(() ->
+                        planService.planDeletion(requester.getId(), plan.getId()))
+                .isInstanceOf(AuthorityException.class)
+                .hasMessage("본인이 요청한 점심약속 만 삭제할 수 있습니다.");
+    }
+
+    @Test
+    public void TestDeletePlan_Fail_TimeRule() {
+        //given
+        User requester = new User();
+        requester.setId(1L);
+
+        User accepter = new User();
+        accepter.setId(2L);
+
+        Plan plan = Plan.builder()
+                .id(1L)
+                .requester(requester)
+                .accepter(accepter)
+                .planRestaurant("a")
+                .planMenu("a")
+                .planTime(LocalDateTime.parse("2023-08-08T00:14:02"))
+                .requestMessage("a")
+                .planStatus(REQUESTED)
+                .RegisteredAt(LocalDateTime.now())
+                .build();
+
+        Mockito.when(planRepository.findById(plan.getId()))
+                .thenReturn(Optional.of(plan));
+
+        //when,then
+        Assertions.assertThatThrownBy(() ->
+                        planService.planDeletion(requester.getId(), plan.getId()))
+                .isInstanceOf(PlanTimeNotMatchedException.class)
+                .hasMessage("약속시간 1시간 이전에만 삭제가 가능합니다.");
+    }
+}


### PR DESCRIPTION
### 추가사항
- 내가 신청한 점심약속 삭제 기능 추가
    - 선택한 점심약속이 존재하는지, 내가 신청한 점심약속이 맞는지 확인
    - 사용자의 id가 Requester 로 등록되었으면서 REQUESTED 상태인
      점심약속이라면, 점심약속 삭제
    - 내가 신청한 점심약속이 아닌경우 -> AuthorityException 예외
    - 상태가 REQUESTED 가 아닐경우 -> AuthorityException 예외
    - 현재~점심시간까지 1시간 미만 남았을 경우 -> PlanTimeNotMatchedException 예외
- PlanTimeNotMatchedException 예외 추가
   - 점심약속 삭제 시 약속시간 이 1시간 미만 남았을 때
    - 관련하여 GlobalExceptionHandler 수정

##### 테스트
- [x] 테스트 코드
- [x] API 테스트