### PR TITLE
Feature/user information

### DIFF
--- a/src/main/java/com/grablunchtogether/domain/User.java
+++ b/src/main/java/com/grablunchtogether/domain/User.java
@@ -3,13 +3,13 @@ package com.grablunchtogether.domain;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
 
-@Data
+@Getter
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
@@ -46,5 +46,17 @@ public class User {
 
     @Column
     private LocalDateTime registeredAt;
+
+    public void update(String userPhoneNumber, String company, Double latitude,
+                       Double longitude){
+        this.userPhoneNumber = userPhoneNumber;
+        this.company = company;
+        this.latitude = latitude;
+        this.longitude = longitude;
+    }
+
+    public void changePassword(String newPassword){
+        this.userPassword = newPassword;
+    }
 }
 

--- a/src/main/java/com/grablunchtogether/service/user/UserServiceImpl.java
+++ b/src/main/java/com/grablunchtogether/service/user/UserServiceImpl.java
@@ -100,10 +100,8 @@ public class UserServiceImpl implements UserService {
         String userPhoneNumber =
                 userInformationEditInput.getUserPhoneNumber().replaceAll("\\D", "");
 
-        user.setUserPhoneNumber(userPhoneNumber);
-        user.setCompany(userInformationEditInput.getCompany());
-        user.setLatitude(coordinate.getLatitude());
-        user.setLongitude(coordinate.getLongitude());
+        user.update(userPhoneNumber,userInformationEditInput.getCompany(),
+                coordinate.getLatitude(),coordinate.getLongitude());
 
         userRepository.save(user);
 
@@ -129,7 +127,7 @@ public class UserServiceImpl implements UserService {
         String encryptedPassword =
                 PasswordUtility.getEncryptPassword(userChangePasswordInput.getUserNewPassword());
 
-        user.setUserPassword(encryptedPassword);
+        user.changePassword(encryptedPassword);
 
         userRepository.save(user);
 


### PR DESCRIPTION
### 변경사항
- `@Data` 대신 `@Getter`로 엔티티 내부 리팩터링
- 엔티티 업데이트 시 별도 메서드 사용
##### AS-IS
- User Entity에서 `@Data` 어노테이션을 사용중이었음. 
- UserService 에서 고객 정보 수정 시 `.setColumn()` 을 사용하고 있었음.  
##### TO-BE
- User Entity의 `@Data` -> `@Getter` 로 수정 
- UserService 에서 고객 정보 수정 시 별도 메서드 사용하여 수정  
##### 테스트
- [x] API 테스트