### PR TITLE
refactor : Swagger UI 에 노출 될 ApiOperation 어노테이션 추가

### DIFF
--- a/src/main/java/com/grablunchtogether/controller/MustEatPlaceController.java
+++ b/src/main/java/com/grablunchtogether/controller/MustEatPlaceController.java
@@ -6,6 +6,7 @@ import com.grablunchtogether.dto.user.UserDto;
 import com.grablunchtogether.service.mustEatPlace.MustEatPlaceService;
 import com.grablunchtogether.service.user.UserService;
 import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
@@ -20,6 +21,7 @@ public class MustEatPlaceController {
     private final MustEatPlaceService mustEatPlaceService;
 
     @GetMapping("/list/{city}")
+    @ApiOperation(value = "맛집목록 불러오기", notes = "도시를 입력하여 해당지역의 맛집목록을 조회합니다.")
     public ResponseEntity<?> findMustEatPlaces(
             @PathVariable String city,
             @RequestHeader(HttpHeaders.AUTHORIZATION) String token) {


### PR DESCRIPTION
### 변경사항
- Swagger UI 에 노출 될 `@ApiOperation` 어노테이션 추가
##### AS-IS
- `MustEatPlaceController` 의 api에 `@ApiOperation` 어노테이션 누락되었음
##### TO-BE
- `@ApiOperation` 어노테이션 추가