### PR TITLE
Feature: Refresh token 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,7 @@ dependencies {
     //jjwt
     implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
     implementation 'io.jsonwebtoken:jjwt-impl:0.11.2'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.11.2'
     //redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 

--- a/src/main/java/com/grablunchtogether/config/JwtTokenFilter.java
+++ b/src/main/java/com/grablunchtogether/config/JwtTokenFilter.java
@@ -21,6 +21,7 @@ public class JwtTokenFilter extends OncePerRequestFilter {
             "/api/users/signup/ocr",
             "/api/users/login",
             "/api/users/password/reset",
+            "/api/auth/refresh",
             "/otp/verification",
             "/swagger-ui/index.html",
             "/swagger-ui/**",

--- a/src/main/java/com/grablunchtogether/controller/RefreshTokenController.java
+++ b/src/main/java/com/grablunchtogether/controller/RefreshTokenController.java
@@ -1,0 +1,40 @@
+package com.grablunchtogether.controller;
+
+import com.grablunchtogether.dto.token.RefreshTokenDto;
+import com.grablunchtogether.service.RefreshTokenService;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+import static com.grablunchtogether.dto.token.RefreshTokenDto.*;
+import static org.springframework.http.HttpStatus.OK;
+
+@RequiredArgsConstructor
+@Api(tags = "Refresh Token API", description = "Refresh Token을 이용해 Access Token을 발급받는 Api")
+@RestController
+public class RefreshTokenController {
+    private final RefreshTokenService refreshTokenService;
+
+    @PostMapping("/api/auth/refresh")
+    @ApiOperation(value = "Access 토큰 재발급(고객)", notes = "Refresh 토큰을 입력하여 Access Token을 재발급 받습니다.")
+    public ResponseEntity<Response> reissueAccessTokenForUser(
+            @RequestHeader(HttpHeaders.AUTHORIZATION) String token,
+            @Valid @RequestBody Request tokenRefreshRequest) {
+
+        String refreshToken = tokenRefreshRequest.getRefresh_token();
+
+        // 토큰 재발급 서비스 호출
+        AccessToken tokenRefreshDto =
+                refreshTokenService.issueNewAccessToken(token, refreshToken);
+
+        return ResponseEntity.status(OK).body(RefreshTokenDto.Response.from(tokenRefreshDto));
+    }
+}

--- a/src/main/java/com/grablunchtogether/controller/UserController.java
+++ b/src/main/java/com/grablunchtogether/controller/UserController.java
@@ -32,6 +32,7 @@ public class UserController {
     private final MailSenderService mailSenderService;
     private final JwtTokenProvider jwtTokenProvider;
     private final SMSApiService smsApiService;
+    private final RefreshTokenService refreshTokenService;
 
     @PostMapping("/signup")
     @Transactional
@@ -58,6 +59,18 @@ public class UserController {
         TokenDto.Dto tokenDto = userService.login(loginRequest);
 
         return ResponseEntity.status(OK).body(TokenDto.Response.from(tokenDto));
+    }
+
+    @PostMapping("/logout")
+    @ApiOperation(value = "사용자 로그아웃", notes = "사용자 로그아웃을 진행합니다.")
+    public ResponseEntity<Void> logout(
+            @RequestHeader(HttpHeaders.AUTHORIZATION) String token){
+
+        String userEmail = jwtTokenProvider.getEmailFromToken(token);
+
+        refreshTokenService.deleteRefreshToken(userEmail);
+
+        return ResponseEntity.status(NO_CONTENT).build();
     }
 
     @PatchMapping("/edit")

--- a/src/main/java/com/grablunchtogether/dto/token/RefreshTokenDto.java
+++ b/src/main/java/com/grablunchtogether/dto/token/RefreshTokenDto.java
@@ -1,0 +1,57 @@
+package com.grablunchtogether.dto.token;
+
+import io.swagger.annotations.ApiModel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class RefreshTokenDto {
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    @ApiModel(value = "리프레시토큰 Request")
+    public static class Request {
+        private String refresh_token;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    @ApiModel("리프레시토큰 Dto")
+    public static class Dto {
+        private String email;
+        private String token;
+
+        public static Dto from(String email, String refreshToken) {
+            return Dto.builder()
+                    .email(email)
+                    .token(refreshToken)
+                    .build();
+        }
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    @ApiModel("리프레시토큰 AccessToken")
+    public static class AccessToken {
+        private String accessToken;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    @ApiModel(value = "리프레시토큰 Response")
+    public static class Response {
+        private String accessToken;
+
+        public static Response from(RefreshTokenDto.AccessToken tokenRefreshDto) {
+            return Response.builder().accessToken(tokenRefreshDto.getAccessToken()).build();
+        }
+    }
+}

--- a/src/main/java/com/grablunchtogether/dto/token/TokenDto.java
+++ b/src/main/java/com/grablunchtogether/dto/token/TokenDto.java
@@ -23,7 +23,7 @@ public class TokenDto {
         public static TokenIssuanceDto from(User user) {
             return TokenIssuanceDto.builder()
                     .id(user.getId())
-                    .email(user.getUserName())
+                    .email(user.getUserEmail())
                     .userRole(user.getUserRole())
                     .build();
         }

--- a/src/main/java/com/grablunchtogether/exception/ErrorCode.java
+++ b/src/main/java/com/grablunchtogether/exception/ErrorCode.java
@@ -30,7 +30,8 @@ public enum ErrorCode {
     PLAN_HISTORY_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 약속 히스토리 입니다."),
     USER_REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 리뷰 입니다."),
     CAN_NOT_COMPLETE_PLAN(HttpStatus.BAD_REQUEST, "수락되지 않은 약속입니다."),
-    OTP_IS_INVALID(HttpStatus.BAD_REQUEST, "유효하지 않은 OTP 입니다.");
+    OTP_IS_INVALID(HttpStatus.BAD_REQUEST, "유효하지 않은 OTP 입니다."),
+    REFRESH_CODE_EXPIRED(HttpStatus.UNAUTHORIZED, "리프레시 토큰이 만료되었습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/grablunchtogether/repository/BookmarkSpotRepository.java
+++ b/src/main/java/com/grablunchtogether/repository/BookmarkSpotRepository.java
@@ -3,10 +3,12 @@ package com.grablunchtogether.repository;
 import com.grablunchtogether.domain.BookmarkSpot;
 import com.grablunchtogether.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Optional;
 
+@Repository
 public interface BookmarkSpotRepository extends JpaRepository<BookmarkSpot, Long> {
     List<BookmarkSpot> findByUserId(User user);
 }

--- a/src/main/java/com/grablunchtogether/repository/MustEatPlaceRepository.java
+++ b/src/main/java/com/grablunchtogether/repository/MustEatPlaceRepository.java
@@ -2,9 +2,11 @@ package com.grablunchtogether.repository;
 
 import com.grablunchtogether.domain.MustEatPlace;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
+@Repository
 public interface MustEatPlaceRepository extends JpaRepository<MustEatPlace,Long> {
     List<MustEatPlace> findByCityOrderByRateDesc(String cityName);
 }

--- a/src/main/java/com/grablunchtogether/repository/PlanRepository.java
+++ b/src/main/java/com/grablunchtogether/repository/PlanRepository.java
@@ -5,11 +5,13 @@ import com.grablunchtogether.enums.PlanStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
+@Repository
 public interface PlanRepository extends JpaRepository<Plan, Long> {
     Optional<Plan> findByRequesterIdAndAccepterIdAndPlanStatus(Long requesterId,
                                                                Long accepterId,

--- a/src/main/java/com/grablunchtogether/repository/RefreshTokenRedisRepository.java
+++ b/src/main/java/com/grablunchtogether/repository/RefreshTokenRedisRepository.java
@@ -1,0 +1,30 @@
+package com.grablunchtogether.repository;
+
+import com.grablunchtogether.dto.token.RefreshTokenDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.util.concurrent.TimeUnit;
+
+@Repository
+@RequiredArgsConstructor
+public class RefreshTokenRedisRepository {
+    private final RedisTemplate<String, String> redisTemplate;
+    private static final String GRAB_LUNCH = "auth: ";
+
+    public void save(String email, String refreshToken) {
+        redisTemplate.opsForValue().set(GRAB_LUNCH + email, refreshToken);
+        redisTemplate.expire(GRAB_LUNCH + email, 14 * 24 * 60 * 60, TimeUnit.SECONDS);
+    }
+
+    public RefreshTokenDto.Dto findByKey(String email) {
+        return RefreshTokenDto.Dto.from(
+                GRAB_LUNCH + email, redisTemplate.opsForValue().get(GRAB_LUNCH + email)
+        );
+    }
+
+    public void deleteByKey(String email) {
+        redisTemplate.delete(GRAB_LUNCH + email);
+    }
+}

--- a/src/main/java/com/grablunchtogether/service/RefreshTokenService.java
+++ b/src/main/java/com/grablunchtogether/service/RefreshTokenService.java
@@ -1,0 +1,67 @@
+package com.grablunchtogether.service;
+
+
+import com.grablunchtogether.config.JwtTokenProvider;
+import com.grablunchtogether.domain.User;
+import com.grablunchtogether.dto.token.TokenDto;
+import com.grablunchtogether.exception.CustomException;
+import com.grablunchtogether.repository.RefreshTokenRedisRepository;
+import com.grablunchtogether.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import static com.grablunchtogether.dto.token.RefreshTokenDto.AccessToken;
+import static com.grablunchtogether.dto.token.RefreshTokenDto.Dto;
+import static com.grablunchtogether.exception.ErrorCode.REFRESH_CODE_EXPIRED;
+import static com.grablunchtogether.exception.ErrorCode.USER_INFO_NOT_FOUND;
+
+@RequiredArgsConstructor
+@Service
+public class RefreshTokenService {
+    private final RefreshTokenRedisRepository refreshTokenRedisRepository;
+    private final UserRepository userRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    // 신규 AccessToken 발급
+    public AccessToken issueNewAccessToken(String accessToken, String refreshToken) {
+
+        validateRefreshToken(refreshToken);
+        String userEmail = jwtTokenProvider.getEmailFromToken(refreshToken);
+        User targetUser = userRepository.findByUserEmail(userEmail)
+                .orElseThrow(() -> new CustomException(USER_INFO_NOT_FOUND));
+
+        Dto tokenSubject =
+                refreshTokenRedisRepository.findByKey(targetUser.getUserEmail());
+
+        if (tokenSubject == null) {
+            throw new CustomException(REFRESH_CODE_EXPIRED);
+        }
+
+        User user = findUser(targetUser.getUserEmail());
+
+        String newAccessToken = jwtTokenProvider.issuingAccessToken(
+                TokenDto.TokenIssuanceDto.from(user)
+        );
+        return AccessToken.builder()
+                .accessToken(newAccessToken)
+                .build();
+    }
+
+    // 리프레시 토큰 삭제
+    public void deleteRefreshToken(String email) {
+        refreshTokenRedisRepository.deleteByKey(email);
+    }
+
+    // RefreshToken 유효성 검사
+    private void validateRefreshToken(String refreshToken) {
+        if (!jwtTokenProvider.validateToken(refreshToken)) {
+            throw new CustomException(REFRESH_CODE_EXPIRED);
+        }
+    }
+
+    // User 찾기
+    private User findUser(String userEmail) {
+        return userRepository.findByUserEmail(userEmail)
+                .orElseThrow(() -> new CustomException(USER_INFO_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/grablunchtogether/service/UserService.java
+++ b/src/main/java/com/grablunchtogether/service/UserService.java
@@ -11,6 +11,7 @@ import com.grablunchtogether.dto.user.UserDto;
 import com.grablunchtogether.enums.UserRole;
 import com.grablunchtogether.exception.CustomException;
 import com.grablunchtogether.exception.ErrorCode;
+import com.grablunchtogether.repository.RefreshTokenRedisRepository;
 import com.grablunchtogether.repository.UserOtpRedisRepository;
 import com.grablunchtogether.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -35,9 +36,10 @@ public class UserService {
     private final JwtTokenProvider jwtTokenProvider;
     private final BCryptPasswordEncoder passwordEncoder;
     private final UserOtpRedisRepository userOtpRedisRepository;
+    private final RefreshTokenRedisRepository refreshTokenRedisRepository;
 
     public NaverSmsDto.SmsContent userSignUp(UserDto.SignUpRequest signUpRequest,
-                                             GeocodeDto userCoordinate) throws Exception {
+                                             GeocodeDto userCoordinate) {
 
         //기존회원 조회
         userRepository.findByUserEmail(signUpRequest.getUserEmail())
@@ -99,7 +101,9 @@ public class UserService {
         }
 
         String accessToken = jwtTokenProvider.issuingAccessToken(TokenDto.TokenIssuanceDto.from(user));
-        String refreshToken = null;
+        String refreshToken = jwtTokenProvider.issuingRefreshToken(user.getUserEmail());
+
+        refreshTokenRedisRepository.save(user.getUserEmail(), refreshToken);
 
         return TokenDto.Dto.from(user, accessToken, refreshToken);
     }


### PR DESCRIPTION
### 변경사항
- 리프레시토큰 기능 및 로직 추가 
  - 로그인 시 리프레시 토큰을 발급하고 Redis에 저장
  - 로그아웃 시 리프레시 토큰 삭제
  - 리프레시토큰을 통한 재발급 시도 -> 엑세스 토큰 재발급
  - 해당부분은 화이트 리스트처리 하여 필터링 제외
- 누락된 어노테이션 추가 (`@Repository`)
##### 테스트
- [x] 테스트 코드
- [x] API 테스트