### PR TITLE
Feat: 맛집 데이터베이스 쿼리 캐싱 기능 추가

### DIFF
--- a/src/main/java/com/grablunchtogether/GrabLunchTogetherApplication.java
+++ b/src/main/java/com/grablunchtogether/GrabLunchTogetherApplication.java
@@ -2,9 +2,11 @@ package com.grablunchtogether;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @EnableJpaAuditing
+@EnableCaching
 @SpringBootApplication
 public class GrabLunchTogetherApplication {
 

--- a/src/main/java/com/grablunchtogether/config/RedisConfig.java
+++ b/src/main/java/com/grablunchtogether/config/RedisConfig.java
@@ -3,11 +3,18 @@ package com.grablunchtogether.config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.cache.RedisCacheWriter;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
 
 @Configuration
 @EnableRedisRepositories
@@ -32,5 +39,21 @@ public class RedisConfig {
         redisTemplate.setKeySerializer(new StringRedisSerializer());
 
         return redisTemplate;
+    }
+
+    @Bean
+    public RedisCacheManager cacheManager(RedisConnectionFactory redisConnectionFactory) {
+        RedisCacheConfiguration cacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(Duration.ofDays(1)) // 캐시 만료 기간 1일
+                .serializeKeysWith(
+                        RedisSerializationContext.SerializationPair
+                                .fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(
+                        RedisSerializationContext.SerializationPair
+                                .fromSerializer(new GenericJackson2JsonRedisSerializer()));
+
+        return RedisCacheManager.builder(RedisCacheWriter.lockingRedisCacheWriter(redisConnectionFactory))
+                .cacheDefaults(cacheConfiguration)
+                .build();
     }
 }

--- a/src/main/java/com/grablunchtogether/repository/UserOtpRedisRepository.java
+++ b/src/main/java/com/grablunchtogether/repository/UserOtpRedisRepository.java
@@ -11,17 +11,19 @@ import java.util.concurrent.TimeUnit;
 public class UserOtpRedisRepository {
     private final RedisTemplate<String, String> redisTemplate;
 
+    private static final String GRAB_LUNCH = "otp : ";
+
     public void save(String otp, String email) {
-        redisTemplate.opsForValue().set(otp, email);
+        redisTemplate.opsForValue().set(GRAB_LUNCH + otp, email);
         //3분 뒤 OTP 만료
         redisTemplate.expire(otp, 3, TimeUnit.MINUTES);
     }
 
     public String check(String otp) {
-        return redisTemplate.opsForValue().get(otp);
+        return redisTemplate.opsForValue().get(GRAB_LUNCH + otp);
     }
 
     public void delete(String otp) {
-        redisTemplate.delete(otp);
+        redisTemplate.delete(GRAB_LUNCH + otp);
     }
 }

--- a/src/test/java/com/grablunchtogether/service/mustEatPlace/MustEatPlaceTest.java
+++ b/src/test/java/com/grablunchtogether/service/mustEatPlace/MustEatPlaceTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
+import org.springframework.cache.CacheManager;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -27,13 +28,16 @@ class MustEatPlaceTest {
     @Mock
     private MustEatPlaceRepository mustEatPlaceRepository;
 
+    @Mock
+    private CacheManager cacheManager;
+
     private MustEatPlaceService mustEatPlaceService;
 
     @BeforeEach
     public void setup() {
         MockitoAnnotations.initMocks(this);
         mustEatPlaceService =
-                new MustEatPlaceService(mustEatPlaceRepository);
+                new MustEatPlaceService(mustEatPlaceRepository,cacheManager);
     }
 
     @Test

--- a/src/test/java/com/grablunchtogether/service/user/UserEditInformationTest.java
+++ b/src/test/java/com/grablunchtogether/service/user/UserEditInformationTest.java
@@ -5,6 +5,7 @@ import com.grablunchtogether.domain.User;
 import com.grablunchtogether.dto.geocode.GeocodeDto;
 import com.grablunchtogether.dto.user.UserDto;
 import com.grablunchtogether.exception.CustomException;
+import com.grablunchtogether.repository.RefreshTokenRedisRepository;
 import com.grablunchtogether.repository.UserOtpRedisRepository;
 import com.grablunchtogether.repository.UserRepository;
 import com.grablunchtogether.service.UserService;
@@ -31,13 +32,21 @@ class UserEditInformationTest {
     private BCryptPasswordEncoder passwordEncoder;
     @Mock
     private UserOtpRedisRepository userOtpRedisRepository;
+    @Mock
+    private RefreshTokenRedisRepository refreshTokenRedisRepository;
     private UserService userService;
 
     @BeforeEach
     public void setup() {
         MockitoAnnotations.initMocks(this);
         userService =
-                new UserService(userRepository,jwtTokenProvider,passwordEncoder,userOtpRedisRepository);
+                new UserService(
+                        userRepository,
+                        jwtTokenProvider,
+                        passwordEncoder,
+                        userOtpRedisRepository,
+                        refreshTokenRedisRepository
+                );
     }
 
     @Test

--- a/src/test/java/com/grablunchtogether/service/user/UserFindUserAroundTest.java
+++ b/src/test/java/com/grablunchtogether/service/user/UserFindUserAroundTest.java
@@ -2,6 +2,7 @@ package com.grablunchtogether.service.user;
 
 import com.grablunchtogether.config.JwtTokenProvider;
 import com.grablunchtogether.dto.user.UserDistanceDto;
+import com.grablunchtogether.repository.RefreshTokenRedisRepository;
 import com.grablunchtogether.repository.UserOtpRedisRepository;
 import com.grablunchtogether.repository.UserRepository;
 import com.grablunchtogether.service.UserService;
@@ -30,13 +31,21 @@ class UserFindUserAroundTest {
     private BCryptPasswordEncoder passwordEncoder;
     @Mock
     private UserOtpRedisRepository userOtpRedisRepository;
+    @Mock
+    private RefreshTokenRedisRepository refreshTokenRedisRepository;
+
     private UserService userService;
 
     @BeforeEach
     public void setup() {
         MockitoAnnotations.initMocks(this);
         userService =
-                new UserService(userRepository,jwtTokenProvider,passwordEncoder,userOtpRedisRepository);
+                new UserService(
+                        userRepository,
+                        jwtTokenProvider,
+                        passwordEncoder,
+                        userOtpRedisRepository,
+                        refreshTokenRedisRepository);
     }
 
     @Test

--- a/src/test/java/com/grablunchtogether/service/user/UserLoginTest.java
+++ b/src/test/java/com/grablunchtogether/service/user/UserLoginTest.java
@@ -6,6 +6,7 @@ import com.grablunchtogether.domain.User;
 import com.grablunchtogether.dto.token.TokenDto;
 import com.grablunchtogether.enums.UserRole;
 import com.grablunchtogether.exception.CustomException;
+import com.grablunchtogether.repository.RefreshTokenRedisRepository;
 import com.grablunchtogether.repository.UserOtpRedisRepository;
 import com.grablunchtogether.repository.UserRepository;
 import com.grablunchtogether.service.UserService;
@@ -33,13 +34,21 @@ class UserLoginTest {
     private BCryptPasswordEncoder passwordEncoder;
     @Mock
     private UserOtpRedisRepository userOtpRedisRepository;
+    @Mock
+    private RefreshTokenRedisRepository refreshTokenRedisRepository;
     private UserService userService;
 
     @BeforeEach
     public void setup() {
         MockitoAnnotations.initMocks(this);
         userService =
-                new UserService(userRepository,jwtTokenProvider,passwordEncoder,userOtpRedisRepository);
+                new UserService(
+                        userRepository,
+                        jwtTokenProvider,
+                        passwordEncoder,
+                        userOtpRedisRepository,
+                        refreshTokenRedisRepository
+                );
     }
 
     @Test

--- a/src/test/java/com/grablunchtogether/service/user/UserPasswordChangeTest.java
+++ b/src/test/java/com/grablunchtogether/service/user/UserPasswordChangeTest.java
@@ -4,6 +4,7 @@ import com.grablunchtogether.config.JwtTokenProvider;
 import com.grablunchtogether.domain.User;
 import com.grablunchtogether.dto.user.UserDto.PasswordChangeRequest;
 import com.grablunchtogether.exception.CustomException;
+import com.grablunchtogether.repository.RefreshTokenRedisRepository;
 import com.grablunchtogether.repository.UserOtpRedisRepository;
 import com.grablunchtogether.repository.UserRepository;
 import com.grablunchtogether.service.UserService;
@@ -30,13 +31,21 @@ class UserPasswordChangeTest {
     private BCryptPasswordEncoder passwordEncoder;
     @Mock
     private UserOtpRedisRepository userOtpRedisRepository;
+    @Mock
+    private RefreshTokenRedisRepository refreshTokenRedisRepository;
     private UserService userService;
 
     @BeforeEach
     public void setup() {
         MockitoAnnotations.initMocks(this);
         userService =
-                new UserService(userRepository,jwtTokenProvider,passwordEncoder,userOtpRedisRepository);
+                new UserService(
+                        userRepository,
+                        jwtTokenProvider,
+                        passwordEncoder,
+                        userOtpRedisRepository,
+                        refreshTokenRedisRepository
+                );
     }
 
     @Test

--- a/src/test/java/com/grablunchtogether/service/user/UserSignUpTest.java
+++ b/src/test/java/com/grablunchtogether/service/user/UserSignUpTest.java
@@ -5,6 +5,7 @@ import com.grablunchtogether.domain.User;
 import com.grablunchtogether.dto.geocode.GeocodeDto;
 import com.grablunchtogether.dto.user.UserDto;
 import com.grablunchtogether.exception.CustomException;
+import com.grablunchtogether.repository.RefreshTokenRedisRepository;
 import com.grablunchtogether.repository.UserOtpRedisRepository;
 import com.grablunchtogether.repository.UserRepository;
 import com.grablunchtogether.service.UserService;
@@ -30,13 +31,21 @@ class UserSignUpTest {
     private BCryptPasswordEncoder passwordEncoder;
     @Mock
     private UserOtpRedisRepository userOtpRedisRepository;
+    @Mock
+    private RefreshTokenRedisRepository refreshTokenRedisRepository;
     private UserService userService;
 
     @BeforeEach
     public void setup() {
         MockitoAnnotations.initMocks(this);
         userService =
-                new UserService(userRepository,jwtTokenProvider,passwordEncoder,userOtpRedisRepository);
+                new UserService(
+                        userRepository,
+                        jwtTokenProvider,
+                        passwordEncoder,
+                        userOtpRedisRepository,
+                        refreshTokenRedisRepository
+                );
     }
 
     @Test


### PR DESCRIPTION
### 변경사항
- 맛집 조회 api호출 시 캐싱을 사용하여 캐시데이터 존재 시 캐시데이터 활용
- 없을 경우 데이터베이스 쿼리 호출 후 캐시 등록
- 스케줄링을 통한 맛집 등록 시에는 캐시 삭제 
##### 테스트
- [x] 테스트 코드
- [x] API 테스트