### PR TITLE
feat : 이메일 발송 기능을 확장성 고려하여 수정 

### DIFF
--- a/src/main/java/com/grablunchtogether/config/AsyncConfig.java
+++ b/src/main/java/com/grablunchtogether/config/AsyncConfig.java
@@ -4,11 +4,13 @@ import com.grablunchtogether.exception.AsyncUncaughtExceptionHandlerCustom;
 import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.AsyncConfigurerSupport;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 import java.util.concurrent.Executor;
 
 @Configuration
+@EnableAsync
 public class AsyncConfig extends AsyncConfigurerSupport {
 
     public Executor getAsyncExecutor() {

--- a/src/main/java/com/grablunchtogether/controller/UserController.java
+++ b/src/main/java/com/grablunchtogether/controller/UserController.java
@@ -2,13 +2,7 @@ package com.grablunchtogether.controller;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.grablunchtogether.config.JwtTokenProvider;
-import com.grablunchtogether.dto.ClovaOcr;
-import com.grablunchtogether.dto.GeocodeDto;
-import com.grablunchtogether.dto.ImageDto;
-import com.grablunchtogether.dto.NaverSmsDto;
-import com.grablunchtogether.dto.TokenDto;
-import com.grablunchtogether.dto.OtpDto;
-import com.grablunchtogether.dto.UserDto;
+import com.grablunchtogether.dto.*;
 import com.grablunchtogether.enums.ImageDirectory;
 import com.grablunchtogether.service.*;
 import io.swagger.annotations.Api;
@@ -26,6 +20,8 @@ import java.net.URISyntaxException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 
+import static com.grablunchtogether.enums.MailComponents.PASSWORD_RESET_SUBJECT;
+import static com.grablunchtogether.enums.MailComponents.PASSWORD_RESET_TEXT;
 import static org.springframework.http.HttpStatus.*;
 
 @RequiredArgsConstructor
@@ -138,7 +134,10 @@ public class UserController {
     public ResponseEntity<Void> ocrSignUp(
             @RequestBody UserDto.PasswordResetRequest passwordResetRequest) {
 
-        mailSenderService.resetPassword(passwordResetRequest);
+        mailSenderService.sendEmail(
+                passwordResetRequest.getEmail(), PASSWORD_RESET_SUBJECT, PASSWORD_RESET_TEXT
+        );
+
         return ResponseEntity.status(NO_CONTENT).build();
     }
 

--- a/src/main/java/com/grablunchtogether/enums/MailComponents.java
+++ b/src/main/java/com/grablunchtogether/enums/MailComponents.java
@@ -1,0 +1,8 @@
+package com.grablunchtogether.enums;
+
+public class MailComponents {
+    public static final String PASSWORD_RESET_TEXT =
+            "새로운 비밀번호 : %s 를 입력해 로그인 해주세요.";
+    public static final String PASSWORD_RESET_SUBJECT =
+            "비밀번호 초기화 완료";
+}

--- a/src/test/java/com/grablunchtogether/service/user/MailSenderServiceTest.java
+++ b/src/test/java/com/grablunchtogether/service/user/MailSenderServiceTest.java
@@ -15,7 +15,8 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
 import javax.mail.internet.MimeMessage;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.grablunchtogether.enums.MailComponents.PASSWORD_RESET_SUBJECT;
+import static com.grablunchtogether.enums.MailComponents.PASSWORD_RESET_TEXT;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.*;
 
@@ -34,7 +35,7 @@ class MailSenderServiceTest {
     @BeforeEach
     public void setup() {
         MockitoAnnotations.initMocks(this);
-        mailSenderService = new MailSenderService(javaMailSender, userRepository,passwordEncoder);
+        mailSenderService = new MailSenderService(javaMailSender, userRepository, passwordEncoder);
     }
 
     @Test
@@ -48,7 +49,7 @@ class MailSenderServiceTest {
         when(userRepository.findByEmail(email)).thenReturn(java.util.Optional.of(existingUser));
 
         // when
-        mailSenderService.resetPassword(resetInput);
+        mailSenderService.sendEmail(resetInput.getEmail(), PASSWORD_RESET_SUBJECT, PASSWORD_RESET_TEXT);
 
         // then
         verify(userRepository, times(1)).save(existingUser);
@@ -64,7 +65,11 @@ class MailSenderServiceTest {
         when(userRepository.findByEmail(email)).thenReturn(java.util.Optional.empty());
 
         // when, then
-        assertThatThrownBy(() -> mailSenderService.resetPassword(resetInput))
+        assertThatThrownBy(() -> mailSenderService.sendEmail(
+                resetInput.getEmail(),
+                PASSWORD_RESET_SUBJECT,
+                PASSWORD_RESET_TEXT)
+        )
                 .isInstanceOf(CustomException.class)
                 .hasMessage("회원정보를 찾을 수 없습니다.");
         verify(javaMailSender, never()).send((MimeMessage) any());


### PR DESCRIPTION
### 변경사항
- 이메일 발송기능을 확장성 있게 수정
##### AS-IS
- 기존의 이메일 발송 메서드는 비밀번호 초기화만을 위한 메일 전송 메서드이었음.
##### TO-BE
- 메일/제목/내용을 전달받아 다른 서비스에서도 사용할 수 있도록 수정

##### 테스트
- [x] 테스트 코드
- [x] API 테스트